### PR TITLE
Mailer

### DIFF
--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,7 +1,9 @@
 class InvitationMailer < ApplicationMailer
-  def demo_invite(users)
-    users.each do |user|
-      mail(to: user.email, subject: 'demo')
-    end
+  def demo_invite
+    @user = params[:user]
+    work_group = params[:work_group]
+    @one_time_password = rand(36**10).to_s(36)
+    @session_url = "https://odaiba-app.netlify.app/classrooms/#{work_group.classroom_id}/work_groups/#{work_group.id}"
+    mail(to: @user.email, subject: 'demo') if @user.update(password: @one_time_password)
   end
 end

--- a/app/mailers/invitation_mailer.rb
+++ b/app/mailers/invitation_mailer.rb
@@ -1,0 +1,7 @@
+class InvitationMailer < ApplicationMailer
+  def demo_invite(users)
+    users.each do |user|
+      mail(to: user.email, subject: 'demo')
+    end
+  end
+end

--- a/app/views/invitation_mailer/demo_invite.html.erb
+++ b/app/views/invitation_mailer/demo_invite.html.erb
@@ -1,0 +1,1 @@
+demo_invite.html.erb

--- a/app/views/invitation_mailer/demo_invite.html.erb
+++ b/app/views/invitation_mailer/demo_invite.html.erb
@@ -1,1 +1,10 @@
-demo_invite.html.erb
+<h3>Invitation for activity</h3>
+
+<p>Dear <%= @user.name %></p>
+<p>You've been invited to collaborate on a worksheet</p>
+<p>You can access it by clicking here: <%= @session_url %></p>
+<p>Please login with the following credentials:</p>
+<ul>
+  <li>Email: <%= @user.email %></li>
+  <li>Password: <%= @one_time_password %></li>
+</ul>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,4 +60,14 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    port:                 587,
+    user_name:            ENV['GMAIL_USERNAME'],
+    password:             ENV['GMAIL_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
 end

--- a/script/test_mail.rb
+++ b/script/test_mail.rb
@@ -1,0 +1,1 @@
+InvitationMailer.with(user: User.last, work_group: WorkGroup.last).demo_invite.deliver_now

--- a/spec/mailers/invitation_mailer_spec.rb
+++ b/spec/mailers/invitation_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe InvitationMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/invitation_mailer_preview.rb
+++ b/spec/mailers/previews/invitation_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/invitation_mailer
+class InvitationMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
while we set up the frontend I wanted to have a way to invite users to use our app that looked a bit more professional
I set up a mailer so that in theory you just pass it the emails and will send an invitation
I'm considering that if FE takes too long we could setup an email listener, so that teachers who wanted to set up a classroom could just send an email with the parameters necessary (like student email, time, etc.) and BE would handle to send everything for them
in any case, we will need to make the email invitation look nicer - @francescheng feel taking on the task?