### PR TITLE
Fixed 'student user own classroom should permit' error

### DIFF
--- a/spec/policies/classroom_policy_spec.rb
+++ b/spec/policies/classroom_policy_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ClassroomPolicy do
     let(:classroom) { create(:classroom) }
 
     context 'own classroom' do
-      let!(:student_classroom) { build(:student_classroom, classroom: classroom, user: user) }
+      let!(:student_classroom) { create(:student_classroom, classroom: classroom, user: user) }
       it { should permit(:index) }
       it { should permit(:show) }
       it { should_not permit(:new) }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36901659/92975427-19210c00-f43d-11ea-8833-d8d1416ee842.png)
I figured the test was failing because this line:` when 'student' then @record.students.include?(@user)` was returning false, but when I ran that line on the console it seemed to be returning the correct bool value. 
Then I thought maybe the Rspec test was wrong? I was looking into the build and create methods and concluded that, while the classroom, student, teacher was being created and saved, the student_classroom wasn't saved?
Not quite sure if this is right solution, but this is what I thought of. Please guide me if it's incorrect or if there are better ways to approach it. Thank you!
