### PR TITLE
Updated rspec rails to 4.0, which fixes the bug that causes a failed test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,10 +71,10 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec'
-  gem 'rspec-rails', '~> 4.0.0'
+  gem 'rspec-rails', '~> 4.0.1'
 end
 
 group :test do
   gem 'simplecov', require: false
-  gem 'rspec-rails', '~> 4.0.0'
+  gem 'rspec-rails', '~> 4.0.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -71,9 +71,10 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '~> 4.0.0'
 end
 
 group :test do
   gem 'simplecov', require: false
+  gem 'rspec-rails', '~> 4.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,7 +323,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 6.0.3, >= 6.0.3.3)
   rspec
-  rspec-rails (~> 4.0.0)
+  rspec-rails (~> 4.0.1)
   sass-rails (>= 6)
   sassc-rails
   simple_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,14 +219,14 @@ GEM
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-rails (3.9.1)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      railties (>= 3.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-      rspec-support (~> 3.9.0)
+    rspec-rails (4.0.1)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
+      rspec-core (~> 3.9)
+      rspec-expectations (~> 3.9)
+      rspec-mocks (~> 3.9)
+      rspec-support (~> 3.9)
     rspec-support (3.9.3)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -323,7 +323,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 6.0.3, >= 6.0.3.3)
   rspec
-  rspec-rails
+  rspec-rails (~> 4.0.0)
   sass-rails (>= 6)
   sassc-rails
   simple_form


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/36901659/94075719-8f642d80-fdb0-11ea-994d-b7eed7fc6e81.png)
The new update fixes this failed test of wrong number of arguments.