### PR TITLE
worksheet template fix

### DIFF
--- a/app/controllers/work_groups_controller.rb
+++ b/app/controllers/work_groups_controller.rb
@@ -7,7 +7,7 @@ class WorkGroupsController < ApplicationController
       @start_time = custom_params[:start_time]
       @start_date = custom_params[:start_date]
     end
-    @worksheet_urls = WorksheetTemplate.all.pluck(:image_url).uniq.select do |url|
+    @worksheet_urls = WorksheetTemplate.where(user_id: 1).pluck(:image_url).select do |url|
       url.include?('res.cloudinary.com/naokimi')
     end
   end


### PR DESCRIPTION
since all workgroups for the demo are created under the first teacher, it makes sense to display only the templates that belong to him rather than all the templates