### PR TITLE
rspec was listed twice in gemfile; deleted one occurrence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,5 +77,4 @@ end
 
 group :test do
   gem 'simplecov', require: false
-  gem 'rspec-rails', '~> 4.0.1'
 end


### PR DESCRIPTION
Rspec was listed twice, in group :development, :test as well as simply group :test.