### PR TITLE
Add uniqness validation for student_classroom

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,5 +77,4 @@ end
 
 group :test do
   gem 'simplecov', require: false
-  gem 'rspec-rails', '~> 4.0.1'
 end

--- a/app/models/student_classroom.rb
+++ b/app/models/student_classroom.rb
@@ -24,6 +24,8 @@ class StudentClassroom < ApplicationRecord
   belongs_to :user
   belongs_to :classroom
 
+  validates :user, uniqueness: { scope: :classroom,
+    message: "should not add the same student to the classroom multiple times" }
   validate :user_role
 
   private

--- a/spec/models/student_classroom_spec.rb
+++ b/spec/models/student_classroom_spec.rb
@@ -52,5 +52,11 @@ RSpec.describe StudentClassroom, type: :model do
       subject.user = create(:teacher)
       expect(subject).not_to be_valid
     end
+
+    it 'when student-classroom pairing already exists' do
+      single_assignment = described_class.create(classroom: classroom, user: student)
+      double_assignment = described_class.new(classroom: classroom, user: student)
+      expect(double_assignment).not_to be_valid
+    end
   end
 end


### PR DESCRIPTION
Students now can't be assigned twice to the same classroom.

This was achieved by making a validation in student_classroom so that no student_classroom can be made that has the same classroom and student pairing.