### PR TITLE
aasm in controller

### DIFF
--- a/app/controllers/api/v1/work_groups_controller.rb
+++ b/app/controllers/api/v1/work_groups_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::WorkGroupsController < Api::V1::BaseController
   acts_as_token_authentication_handler_for User
   before_action :set_and_authorize_classroom, only: %i[new create index]
-  before_action :set_and_authorize_work_group, only: %i[show edit update destroy]
+  before_action :set_and_authorize_work_group, only: %i[show edit update initiate conclude cancel destroy]
 
   def index
     @work_groups = policy_scope(WorkGroup)
@@ -25,6 +25,25 @@ class Api::V1::WorkGroupsController < Api::V1::BaseController
     else
       render_error
     end
+  end
+
+  def initiate
+    return unless @work_group.created?
+
+    @work_group.initiate!
+    render json: @work_group
+  end
+
+  def conclude
+    return unless @work_group.in_progress?
+
+    @work_group.conclude!
+    render json: @work_group
+  end
+
+  def cancel
+    @work_group.cancel!
+    render json: @work_group
   end
 
   def new

--- a/app/policies/work_group_policy.rb
+++ b/app/policies/work_group_policy.rb
@@ -24,6 +24,9 @@ class WorkGroupPolicy < ApplicationPolicy
   alias new? create?
   alias edit? update?
   alias destroy? update?
+  alias initiate? update?
+  alias conclude? update?
+  alias cancel? update?
 
   class Scope < Scope
     def resolve

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { sessions: 'users/sessions' }
 
   devise_scope :user do
-    root to: "devise/sessions#new"
+    root to: 'devise/sessions#new'
   end
 
   resources :user, only: [:show, :update]
@@ -14,9 +14,14 @@ Rails.application.routes.draw do
       resources :classrooms, defaults: { format: :json } do
         resources :work_groups, shallow: true do
           resources :worksheets, except: :destroy, shallow: true
+          member do
+            patch :initiate
+            patch :conclude
+            patch :cancel
+          end
         end
       end
-      
+
       resources :worksheet_templates
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -92,7 +92,6 @@ Classroom.all.each do |classroom|
       turn_time: 300_000, # time in miliseconds, 60000 == 1 minute
       score: 0,
       answered: 0,
-      aasm_state: 'in_progress',
       start_at: DateTime.new(2030, 1, 1, 10, 30)
     )
   end


### PR DESCRIPTION
GOAL: remove reliance on start time of work group for logic. Instead implement work group "status" in case teacher wants freedom to start and conclude coop session

@ivanvgarcia implemented 3 new endpoints (all PATCH):
/api/v1/work_groups/:id/initiate
/api/v1/work_groups/:id/conclude
/api/v1/work_groups/:id/cancel
all of them return just the work group iteslf (without the relations)
let me know if you'd prefer to combine some of those endpoints (or just use the existing default PATCH endpoint) and/or change what gets returned

to the BE code reviewers: please add your review but don't merge until Ivan gives his comment